### PR TITLE
fix: closing when closed no longer throws

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,8 @@ module.exports = function (opts, name) {
     var _closing = closing
     closing = null
     _closing(err)
-    p.read(null, err || true)
+    if (p)
+      p.read(null, err || true)
 
     // deallocate
     p = null

--- a/test/messages.js
+++ b/test/messages.js
@@ -226,3 +226,20 @@ tape('call close cb when the stream is ended', function (t) {
   a.write(null, true)
 })
 
+
+tape('double close', function (t) {
+
+  var a = ps({
+    close: function (err) {
+      console.log('close', err)
+    }
+  })
+
+  console.log('close 1')
+  a.close(function () {
+  console.log('close 2')
+    a.close(function () {
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
this is a bug introduced by https://github.com/dominictarr/packet-stream/pull/1. calling close twice was causing a read attempt on a nullified object.

i dont believe this is a sign of any logical errors. solved by checking if the `p` object exists before attempting the last read.
