### PR TITLE
Bug in tabulation of uncompleted tasks: done > todo

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,8 +148,10 @@ module.exports = function (opts, name) {
       }
       if (!cb) throw new Error('packet-stream.close *must* have callback')
       closing = cb
+      if (done > todo)
+        console.warn('packet-stream bug!! please address this soon: https://github.com/dominictarr/packet-stream/pull/3. done:', done, 'todo:', todo)
       if (force) {
-        done = todo        
+        done = todo
       }
       maybeDone()
     },

--- a/index.js
+++ b/index.js
@@ -141,9 +141,16 @@ module.exports = function (opts, name) {
   }
 
   return p = {
-    close: function (cb) {
-      if(!cb) throw new Error('packet-stream.close *must* have callback')
+    close: function (force, cb) {
+      if (!cb && typeof force == 'function') {
+        cb = force
+        force = undefined
+      }
+      if (!cb) throw new Error('packet-stream.close *must* have callback')
       closing = cb
+      if (force) {
+        done = todo        
+      }
       maybeDone()
     },
     ended: false,


### PR DESCRIPTION
An application connected to scuttlebot over a websocket was not able to close its RPC stream (the `.close()`) when scuttlebot closed and the connection died. When I examined the heap of the `maybeDone` call made by `close`, I found `done=11; todo=10`. This meant that the `maybeDone` completeness check was incorrect:

``` js
function maybeDone (err) {
  if(!closing) return
  if(todo !== done) return // funny stuff
  closed = true
```

This PR is a temporary bandaid which will hopefully bug us into making a real fix.
