### PR TITLE
Rewrite for more explicit memory control, and to fix other bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,8 +137,6 @@ PacketStream.prototype._onrequest = function (msg) {
     // A incoming response
     if (typeof this._requests[rid] == 'function')
       this._requests[rid](msg.error, msg.value)
-    delete this._requests[rid]
-    this._maybedone()
   }
   else {
     // An incoming request

--- a/index.js
+++ b/index.js
@@ -170,6 +170,9 @@ PacketStream.prototype._onstream = function (msg) {
     // Incoming stream data
     var rid = msg.req*-1
     var outs = this._outstreams[rid]
+    if (!outs)
+      return console.error('no stream for incoming msg', msg)
+
     if (msg.end) {
       if (outs.writeEnd)
         delete this._outstreams[rid]

--- a/test/messages.js
+++ b/test/messages.js
@@ -17,11 +17,11 @@ tape('messages', function (t) {
   var b = ps({})
 
   // a.pipe(b).pipe(a)
-  a.read = b.write; b.read = a.write
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   var expected = ['hello', 'foo', 'bar']
 
-  expected.forEach(b.message)
+  expected.forEach(b.message.bind(b))
   t.deepEqual(actual, expected)
 
   t.end()
@@ -40,7 +40,7 @@ tape('request-response', function (t) {
 
   var b = ps({})
 
-  a.read = b.write; b.read = a.write
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   b.request(7, function (err, value) {
     t.notOk(err)
@@ -56,16 +56,13 @@ tape('stream', function (t) {
   var a = ps({
     stream: function (stream) {
       //echo server
-      stream.read = stream.write
+      stream.read = stream.write.bind(stream)
     }
   })
-
   var b = ps({})
-
-  a.read = b.write; b.read = a.write
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   var s = b.stream()
-
   s.read = function (data, end) {
     if(!end)
       actual.push(data)
@@ -111,7 +108,7 @@ tape('close after request finishes', function (t) {
 
   var b = ps({})
 
-  a.read = b.write; b.read = a.write
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   b.request(7, function (err, value) {
     t.notOk(err)
@@ -129,6 +126,8 @@ tape('close after request finishes', function (t) {
 
 tape('streams, close', function (t) {
   t.plan(7)
+  var expected = [1,2,3,3,5]
+
   var a = ps({
     stream: function (stream) {
       //echo server
@@ -139,14 +138,9 @@ tape('streams, close', function (t) {
       }
     }
   })
-
-  var expected = [1,2,3,3,5]
-
   var b = ps({})
-
   var s = b.stream()
-
-  a.read = b.write; b.read = a.write
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   b.close(function (err) {
     t.ok(true)
@@ -177,6 +171,7 @@ tape('receive stream, then close', function (t) {
       }
 
       a.close(function (err) {
+        console.log('close reached', err)
         t.ok(true)
         t.end()
       })
@@ -187,10 +182,8 @@ tape('receive stream, then close', function (t) {
   var expected = [1,2,3,3,5]
 
   var b = ps({})
-
   var s = b.stream()
-
-  a.read = b.write; b.read = a.write
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   s.read = function (data, end) {
     if(end && end !== true) throw end
@@ -262,12 +255,12 @@ tape('properly close if destroy called with a open request', function (t) {
     }
   })
 
-  a.read = b.write; b.read = a.write
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   b.request(7, function (err, value) {
     console.log(err)
   })
 
-  b.destroy()
+  b.destroy(true)
 
 })


### PR DESCRIPTION
@dominictarr this is going to be an annoying PR but I think it was needed. I hate having my code rewritten, especially in a different style, but here's why I did it:

In #3 I figured out how to duplicate the bug, and added a test for it with d0f6617. When I started to fix it, I found more bugs related to the `todo` and `done` tabulation. At this point I said, hmm, we still get occasional crashes from a missing `.read` (because it's called after the stream is closed) and we still have issues with memory leaks. Also, after digging a bit more, I found the close-callbacks could be overwritten if given more than once. I figured it was time to clean this guy up!

So I did a rewrite that tries to be much more explicit about memory (without changing the API). In particular it tries to avoid closures which capture the fn's owning object, avoid sharing closures with multiple fns, and be very explicit about releasing all captured references. It also fixes the reported bugs (lack of support for multiple close cbs, the bug reported in #3) and protects against bad references after the stream is closed (`.read` is assigned to a function that logs the mistake without crashing).

The only external change is that methods on the given PacketStream have to have their `this` explicitly managed. So the lines in the test like:

``` js
a.read = b.write; b.read = a.write
```

had to become

``` js
a.read = b.write.bind(b); b.read = a.write.bind(a)
```

I've tested against muxrpc and scuttlebot. Muxrpc needs two small changes, which I'll show in a PR. One of them had to do with the need for `.bind`, and the other was a bug exposed by the `close` callbacks now all getting called.
