### PR TITLE
Destroy stream without sending a message for each substream

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,18 @@ PacketStream.prototype.destroy = function (end) {
   // force-close all requests and substreams
   var numended = 0
   for (var k in this._requests)   { numended++; this._requests[k](err) }
-  for (var k in this._instreams)  { numended++; this._instreams[k].destroy(err) }
-  for (var k in this._outstreams) { numended++; this._outstreams[k].destroy(err) }
+  for (var k in this._instreams)  {
+    numended++
+    // destroy substream without sending it a message
+    this._instreams[k].writeEnd = true
+    this._instreams[k].destroy(err)
+  }
+  for (var k in this._outstreams) {
+    numended++
+    // destroy substream without sending it a message
+    this._outstreams[k].writeEnd = true
+    this._outstreams[k].destroy(err)
+  }
 
   //from the perspective of the outside stream it's not an error
   //if the stream was in a state that where end was okay. (no open requests/streams)

--- a/test/messages.js
+++ b/test/messages.js
@@ -264,3 +264,26 @@ tape('properly close if destroy called with a open request', function (t) {
   b.destroy(true)
 
 })
+
+tape('destroy sends not more than one message', function (t) {
+  var a = ps({
+    close: function (err) {
+      t.end()
+    }
+  })
+
+  var msgs = 0
+  a.read = function (msg, end) {
+    if (end) return t.ok(end)
+    msgs++
+    if (msgs > 1) t.fail(msgs)
+    else t.ok(msg)
+  }
+
+  var s1 = a.stream()
+  var s2 = a.stream()
+  s1.read = function () {}
+  s2.read = function () {}
+
+  a.destroy(true)
+})


### PR DESCRIPTION
As discussed in #6, this makes `ps.destroy` just close the underlying stream, without sending an end message for each substream. This means that an error object given to `ps.destroy` will only get passed to the local end of the substreams, not sent to the other end. If the other end properly detects the end of the stream, it will get the close event and turn it into an "expected end of parent stream" error originating locally in response to the stream being closed.