### PR TITLE
Pre-emptively destroy stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,18 @@ PacketStream.prototype.destroy = function (end) {
   // force-close all requests and substreams
   var numended = 0
   for (var k in this._requests)   { numended++; this._requests[k](err) }
-  for (var k in this._instreams)  { numended++; this._instreams[k].destroy(err) }
-  for (var k in this._outstreams) { numended++; this._outstreams[k].destroy(err) }
+  for (var k in this._instreams)  {
+    numended++
+    // destroy substream without sending it a message
+    this._instreams[k].writeEnd = true
+    this._instreams[k].destroy(err)
+  }
+  for (var k in this._outstreams) {
+    numended++
+    // destroy substream without sending it a message
+    this._outstreams[k].writeEnd = true
+    this._outstreams[k].destroy(err)
+  }
 
   //from the perspective of the outside stream it's not an error
   //if the stream was in a state that where end was okay. (no open requests/streams)

--- a/index.js
+++ b/index.js
@@ -184,6 +184,13 @@ PacketStream.prototype._onrequest = function (msg) {
 
 // Internal handler of incoming stream msgs
 PacketStream.prototype._onstream = function (msg) {
+  if(msg.end && msg.value
+    && msg.value.message === 'unexpected end of parent stream') {
+    // The other end is closing the stream with the legacy destroy method.
+    // End the stream early to drop the rest of the incoming error messages.
+    return this.destroy(msg.value)
+  }
+
   if(msg.req < 0) {
     // Incoming stream data
     var rid = msg.req*-1

--- a/test/legacy.js
+++ b/test/legacy.js
@@ -1,0 +1,48 @@
+var tape = require('tape')
+
+var ps = require('../')
+
+tape('abort streams if receive "unexpected end of parent stream"', function (t) {
+  t.plan(6)
+
+  var s1a, s2a
+  var a = ps({
+    stream: function (stream) {
+      if(!s1a) {
+        s1a = stream
+        s1a.read = function (data, end) {
+          if(data) t.ok(data, 's1a got data')
+          else t.ok(end, 's1a ended')
+        }
+      } else if(!s2a) {
+        s2a = stream
+        s2a.read = function (data, end) {
+          if(data) t.ok(data, 's2a got data')
+          else t.ok(end, 's2a ended')
+        }
+      } else {
+        t.fail('too many substreams')
+      }
+    }
+  })
+
+  var b = ps({})
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
+
+  var s1b = b.stream()
+  s1b.read = function (data, end) {
+    t.ok(end, 's1 ended')
+  }
+
+  var s2b = b.stream()
+  s2b.read = function (data, end) {
+    t.ok(end, 's2 ended')
+  }
+
+  // send data to open the streams
+  s1b.write('hi')
+  s2b.write('hi')
+
+  // simulate packet-stream <= 2.0.0 starting to destroy the parent stream
+  s1b.write(null, new Error('unexpected end of parent stream'))
+})

--- a/test/messages.js
+++ b/test/messages.js
@@ -264,3 +264,26 @@ tape('properly close if destroy called with a open request', function (t) {
   b.destroy(true)
 
 })
+
+tape('destroy sends not more than one message', function (t) {
+  var a = ps({
+    close: function (err) {
+      t.end()
+    }
+  })
+
+  var msgs = 0
+  a.read = function (msg, end) {
+    if (end) return t.ok(end)
+    msgs++
+    if (msgs > 1) t.fail(msgs)
+    else t.ok(msg)
+  }
+
+  var s1 = a.stream()
+  var s2 = a.stream()
+  s1.read = function () {}
+  s2.read = function () {}
+
+  a.destroy(true)
+})


### PR DESCRIPTION
This follows #7 but is actually an independent change. It is an optimization to save bandwidth and event loop time. In packet-stream before #7, calling destroy triggers sending an end message for each substream (see #6). In scuttlebot, bandwidth use and responsiveness of the program have been a problem, which I think the packet-stream end messages have been contributing to. This PR detects if a message is arriving that indicates the stream is being closed by a remote packet-stream pre-#7, and pre-emptively destroys the stream so that the rest of the incoming end messages are dropped. This is intended to save bandwidth in the case where there the dropped messages are larger than the TCP receive window, so that the other end might stop sending them, or at least handling of the packets can be pushed down to the OS/network layer, rather than blocking the nodejs event loop.