### PR TITLE
don't attempt to read stream after it has been destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,12 +78,14 @@ PacketStream.prototype.destroy = function (end) {
     numended++
     // destroy substream without sending it a message
     this._instreams[k].writeEnd = true
+    this._instreams[k].readEnd = true
     this._instreams[k].destroy(err)
   }
   for (var k in this._outstreams) {
     numended++
     // destroy substream without sending it a message
     this._outstreams[k].writeEnd = true
+    this._outstreams[k].readEnd = true
     this._outstreams[k].destroy(err)
   }
 


### PR DESCRIPTION
My understanding of what is going on here is pretty limited, but I have discovered that if destroy also **prevents all future reads** (in additional to writes) for a packet stream, it solves the mysterious 10-50 seconds of blocking I get when a stream tries to destroy after the connection has already closed.

See [%GbJVNVx4jcO6kmrdrRsZ3RUyXeoPRKKf8vsM6s5v0EQ=.sha256](https://viewer.scuttlebot.io/%25GbJVNVx4jcO6kmrdrRsZ3RUyXeoPRKKf8vsM6s5v0EQ%3D.sha256) for full commentary.

Tests seem to pass, so one would assume this is okay to merge! I'k gonna go ahead and run this fork in patchwork for a while and see if anything else mysteriously breaks.

cc @dominictarr @clehner 