### PR TITLE
Fix destroy() so its error is passed to the close() callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ PacketStream.prototype.request = function (obj, cb) {
   this._requests[rid] = function (err, value) {
     delete self._requests[rid]
     cb(err, value)
-    self._maybedone()
+    self._maybedone(err)
   }
   this.read({ req:rid, stream: false, end: false, value: obj })
 }

--- a/index.js
+++ b/index.js
@@ -250,8 +250,8 @@ PacketStreamSubstream.prototype.write = function (data, err) {
     if (ps) {
       ps.read({ req: this.id, stream: true, end: true, value: flat(err) })
       if (this.readEnd)
-        this.destroy()
-      ps._maybedone()
+        this.destroy(err)
+      ps._maybedone(err)
     }
   }
   else {

--- a/test/messages.js
+++ b/test/messages.js
@@ -9,7 +9,6 @@ tape('messages', function (t) {
 
   var a = ps({
     message: function (msg) {
-      console.log('MSG', msg)
       actual.push(msg)
     }
   })
@@ -171,7 +170,6 @@ tape('receive stream, then close', function (t) {
       }
 
       a.close(function (err) {
-        console.log('close reached', err)
         t.ok(true)
         t.end()
       })
@@ -227,13 +225,10 @@ tape('double close', function (t) {
 
   var a = ps({
     close: function (err) {
-      console.log('close', err)
     }
   })
 
-  console.log('close 1')
   a.close(function () {
-  console.log('close 2')
     a.close(function () {
       t.end()
     })
@@ -250,7 +245,6 @@ tape('properly close if destroy called with a open request', function (t) {
 
   var b = ps({
     close: function (err) {
-      console.log('close')
       t.end()
     }
   })
@@ -258,7 +252,6 @@ tape('properly close if destroy called with a open request', function (t) {
   a.read = b.write.bind(b); b.read = a.write.bind(a)
 
   b.request(7, function (err, value) {
-    console.log(err)
   })
 
   b.destroy(true)

--- a/test/messages.js
+++ b/test/messages.js
@@ -287,3 +287,29 @@ tape('destroy sends not more than one message', function (t) {
 
   a.destroy(true)
 })
+
+tape('ensure properly close if destroy called with a open request', function (t) {
+
+  const expectedError = new Error('a sudden but inevitable close')
+
+  var a = ps({
+    request: function (value, cb) {
+      // never calls cb
+    }
+  })
+
+  var b = ps({
+    close: function (err) {
+      t.deepEquals(err, expectedError, 'close err matches')
+      t.end()
+    }
+  })
+
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
+
+  b.request(7, function (err, value) {
+    t.deepEquals(err, expectedError, 'request err matches')
+  })
+
+  b.destroy(expectedError)
+})


### PR DESCRIPTION
Previously destroy(err) would cancel each outstanding RPC, which would call
_maybedone() *before* destroy() got the chance to, causing the original
error destroy() was called with to be lost.