### PR TITLE
increase code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 test/
 .github/
+.nyc_output

--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ PacketStream.prototype._onrequest = function (msg) {
       })
     } else {
       if (this.ended) {
+        // FIXME: this block seems unreachable because of line 131
         var err = (this.ended === true)
           ? new Error('unexpected end of parent stream')
           : this.ended

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
     "url": "git://github.com/ssbc/packet-stream.git"
   },
   "devDependencies": {
+    "nyc": "^15.1.0",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",
     "tape": "~5.2.2"
   },
   "scripts": {
     "prepublishOnly": "npm test",
-    "test": "tape test/*.js | tap-bail | tap-spec"
+    "test": "tape test/*.js | tap-bail | tap-spec",
+    "coverage": "nyc npm run test"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"


### PR DESCRIPTION
Added `nyc` for code coverage. And then added a few more tests for some easy cases to cover.

Coverage before:

```
----------|---------|----------|---------|---------|-----------------------------------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                             
----------|---------|----------|---------|---------|-----------------------------------------------
All files |   86.17 |    74.77 |   91.67 |   87.72 |                                               
 index.js |   86.17 |    74.77 |   91.67 |   87.72 | 4,119,125,169-183,195,222,231,270-281,290-291 
----------|---------|----------|---------|---------|-----------------------------------------------
```

Coverage after:

```
----------|---------|----------|---------|---------|-----------------------------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                       
----------|---------|----------|---------|---------|-----------------------------------------
All files |   89.36 |    80.18 |   95.83 |   90.64 |                                         
 index.js |   89.36 |    80.18 |   95.83 |   90.64 | 119,171-174,195,222,231,270-281,290-291 
----------|---------|----------|---------|---------|-----------------------------------------
```