### PR TITLE
add benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/ssbc/packet-stream.git"
   },
   "devDependencies": {
+    "cont": "1.0.3",
     "nyc": "^15.1.0",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",

--- a/test/bench.js
+++ b/test/bench.js
@@ -1,0 +1,54 @@
+const cont = require('cont')
+const ps = require('../')
+
+console.log("name, ops, opts/second, seconds")
+function Timer (name) {
+  var start = Date.now()
+  return function (ops) {
+    var seconds = (Date.now() - start)/1000
+    console.log([name, ops, ops/seconds, seconds].join(', '))
+  }
+}
+
+function bunch_of_substreams (N, _, cb) {
+  var items = Array(200).fill(0).map((_, i) => i * 10)
+
+  var a = ps({
+    stream: function (stream) {
+      //echo server
+      stream.read = stream.write.bind(stream)
+    }
+  })
+  var b = ps({})
+  a.read = b.write.bind(b); b.read = a.write.bind(a)
+
+  for (var i = 0; i < N; i++) {
+    var s = b.stream()
+    s.read = function (data, end) {
+    }
+    items.forEach(function (data) {
+      s.write(data)
+    })
+    s.end()
+  }
+
+  cb(null, N)
+}
+
+var N = 150e3
+
+function run(name, benchmark, opts) {
+  return function (cb) {
+    var t = Timer(name)
+    benchmark(N, opts, function (err, n) {
+      t(err || n)
+      cb()
+    })
+  }
+}
+
+cont.series([
+  run('bunch_of_substreams', bunch_of_substreams),
+]) (function () {
+  // teardown logic here
+})


### PR DESCRIPTION
Just creating a ton of substreams and putting 200 items through each.

Some runs on my computer:

TL;DR **39k ops/sec** ± 1k ops/sec

```
➜  packet-stream git:(bench) node test/bench.js 
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 38880.24883359254, 3.858
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 38639.87635239567, 3.882
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 39609.18933192501, 3.787
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 40096.230954290295, 3.741
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 38363.17135549872, 3.91
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 38779.73112719752, 3.868
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 38119.44091486658, 3.935
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 39277.29772191673, 3.819
➜  packet-stream git:(bench) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 38530.69612124326, 3.893
```