### PR TITLE
use ES6 Map and other ES6 features

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "tap-spec": "^5.0.0",
     "tape": "~5.2.2"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "scripts": {
     "prepublishOnly": "npm test",
     "test": "tape test/*.js | tap-bail | tap-spec",

--- a/substream.js
+++ b/substream.js
@@ -1,22 +1,19 @@
-var utils = require('./utils')
-var flat = utils.flat
-var closedread = utils.closedread
+const {flat, closedread} = require('./utils')
 
 function PacketStreamSubstream (id, ps, remove) {
   this.id       = id
-  this.read     = null // must release, may capture `this`
+  this.read     = null   // must release, may capture `this`
   this.writeEnd = null
   this.readEnd  = null
 
-  this._ps          = ps     // must release, may capture `this`
-  this._remove      = remove // must release, may capture `this`
-  this._seq_counter = 1
+  this._ps      = ps     // must release, may capture `this`
+  this._remove  = remove // must release, may capture `this`
 }
 
 PacketStreamSubstream.prototype.write = function (data, err) {
+  const ps = this._ps
   if (err) {
     this.writeEnd = err
-    var ps = this._ps
     if (ps) {
       ps.read({ req: this.id, stream: true, end: true, value: flat(err) })
       if (this.readEnd)
@@ -25,7 +22,7 @@ PacketStreamSubstream.prototype.write = function (data, err) {
     }
   }
   else {
-    if (this._ps) this._ps.read({ req: this.id, stream: true, end: false, value: data })
+    if (ps) ps.read({ req: this.id, stream: true, end: false, value: data })
   }
 }
 

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,6 @@
 function flat(err) {
-  if(!err) return err
-  if(err === true) return true
+  if (!err) return err
+  if (err === true) return true
   return {message: err.message, name: err.name, stack: err.stack}
 }
 


### PR DESCRIPTION
`delete` in JS is always a sign of bad performance, so I replaced objects with `Map`. Also took the opportunity to use ES2017+ features wherever they made sense, since we're updating the code anyways. This will require Node 8+, but that should be safe for everyone nowadays.

Performance after:

TL;DR **42k ops/sec** ± 1k ops/sec

```
➜  packet-stream git:(es6) node test/bench.js                             
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 42099.35447656469, 3.563
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 43177.89291882556, 3.474
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 41129.69564025226, 3.647
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 43004.5871559633, 3.488
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 42553.19148936171, 3.525
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 41276.82993946065, 3.634
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 42277.339346110486, 3.548
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 42289.258528333805, 3.547
➜  packet-stream git:(es6) node test/bench.js
name, ops, opts/second, seconds
bunch_of_substreams, 150000, 41107.152644560156, 3.649
```